### PR TITLE
Fix loading screen reappearance issue on back navigation

### DIFF
--- a/lib/screens/loading_screen.dart
+++ b/lib/screens/loading_screen.dart
@@ -21,6 +21,7 @@ class _LoadingScreenState extends State<LoadingScreen> {
   void initState() {
     // will be called once whenever your app is initialised ,
     super.initState();
+    getLocationData();
     // getLocationData();
   }
 
@@ -48,7 +49,7 @@ await
   void getLocationData() async {
     WeatherModel weatherModel = WeatherModel();
     var weatherData = await weatherModel.getLocationWeather();
-    Navigator.push(
+    Navigator.pushReplacement(
       context,
       MaterialPageRoute(
         builder: (context) {
@@ -60,7 +61,6 @@ await
 
   @override
   Widget build(BuildContext context) {
-    getLocationData();
     return Scaffold(
       body: Center(
         child: SpinKitPouringHourGlassRefined(


### PR DESCRIPTION
This commit addresses a bug in the Flutter application where the loading screen would reappear when navigating back from the main screen. The issue was caused by incorrect state management or navigation handling that led to the loading screen being redisplayed upon pressing the back button.

Changes Made:

Modified navigation logic to ensure that the loading screen does not reappear when returning to the previous screen.
Adjusted state management to properly handle the transition between screens and maintain the correct application state.

Impact:
This fix improves the user experience by ensuring that the application transitions smoothly between screens without unintended UI elements reappearing.

